### PR TITLE
Allows simple pass thru of full 'target: *.xyz'

### DIFF
--- a/jobs/bosh-dns-aliases/spec
+++ b/jobs/bosh-dns-aliases/spec
@@ -22,3 +22,6 @@ properties:
         deployment: cf_123
         network: default
         domain: bosh
+    - domain: tcp-router.service.cf.internal
+      targets:
+      - target: '*.tcp-router.default.cf.bosh'

--- a/jobs/bosh-dns-aliases/templates/aliases.json.erb
+++ b/jobs/bosh-dns-aliases/templates/aliases.json.erb
@@ -10,6 +10,7 @@ aliases = p("aliases").map do |a|
   [
     a.fetch("domain"),
     a.fetch("targets").map do |t|
+      t.fetch("target", nil) ||
       [
         t.fetch("query"),
         canonicalize(t.fetch("instance_group")),


### PR DESCRIPTION
This will help convert cf-deployment use-bosh-dns.yml
e.g. https://github.com/cloudfoundry/cf-deployment/pull/341