### PR TITLE
Update bundler and lock ruby version to fix osl pipeline

### DIFF
--- a/spec/Gemfile
+++ b/spec/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
-
+ruby '2.7.3'
 gem 'bosh-template'

--- a/spec/Gemfile.lock
+++ b/spec/Gemfile.lock
@@ -11,5 +11,8 @@ PLATFORMS
 DEPENDENCIES
   bosh-template
 
+RUBY VERSION
+   ruby 2.7.3p183
+
 BUNDLED WITH
-   1.11.0
+   2.1.4


### PR DESCRIPTION
Should fix this build: https://norsk.cf-app.com/teams/norsk-viewers/pipelines/elastic-runtime-2.11.0-update-dependencies-RDOSS/jobs/cloudfoundry-bosh-dns-aliases-release-v0.0.3-report/builds/10

Related tracker story: https://www.pivotaltracker.com/story/show/178147974