### PR TITLE
Add lightweight testing across ruby versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: test-with-ruby-versions
+on:
+  pull_request:
+    paths:
+      - '**/**'
+    branches: [ "master" ]
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.7', '3.1']
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: |
+        #!/bin/bash
+        set -x
+        RUBY_VERSION=$(ruby --version | sed 's/ruby \(.*\)p.*/\1/')
+        cd spec 
+        sed -i  "s/ruby .*/ruby '$RUBY_VERSION'/g" ./Gemfile
+        bundle install
+        gem install rspec
+        rspec bosh-dns-aliases_spec.rb

--- a/spec/bosh-dns-aliases_spec.rb
+++ b/spec/bosh-dns-aliases_spec.rb
@@ -11,7 +11,7 @@ describe 'bosh-dns-aliases job' do
     let(:template) { job.template('dns/aliases.json') }
 
     it 'canonicalizes DNS labels' do
-      tpl_output = template.render(
+      tpl_output = template.render({
         'aliases' => [{
           'domain' => 'credhub.cf.internal',
           'targets' => [{
@@ -28,7 +28,7 @@ describe 'bosh-dns-aliases job' do
             'domain' => 'bosh2',
           }]
         }]
-      )
+      })
 
       expect(JSON.parse(tpl_output)).to eq({
         "credhub.cf.internal" => [
@@ -40,19 +40,19 @@ describe 'bosh-dns-aliases job' do
 
     it 'raises error if targets are not present' do
       expect {
-        tpl_output = template.render(
+        tpl_output = template.render({
           'aliases' => [{
             'domain' => 'credhub.cf.internal',
           }]
-        )
+        })
       }.to raise_error /key not found: "targets"/
     end
 
     it 'raises error if domain is not present' do
       expect {
-        tpl_output = template.render(
+        tpl_output = template.render({
           'aliases' => [{}]
-        )
+        })
       }.to raise_error /key not found: "domain"/
     end
 
@@ -90,7 +90,7 @@ describe 'bosh-dns-aliases job' do
     end
 
     it 'canonicalizes by all of special rules' do
-      tpl_output = template.render(
+      tpl_output = template.render({
         'aliases' => [{
           'domain' => 'credhub.cf.internal',
           'targets' => [{
@@ -101,7 +101,7 @@ describe 'bosh-dns-aliases job' do
             'domain' => 'bosh1^', # not canonicalized
           }]
         }]
-      )
+      })
 
       expect(JSON.parse(tpl_output)).to eq({
         "credhub.cf.internal" => [
@@ -111,7 +111,7 @@ describe 'bosh-dns-aliases job' do
     end
 
     it 'keeps wildcard "*" identifier as is' do
-      tpl_output = template.render(
+      tpl_output = template.render({
         'aliases' => [{
           'domain' => 'credhub.cf.internal',
           'targets' => [{
@@ -122,7 +122,7 @@ describe 'bosh-dns-aliases job' do
             'domain' => 'bosh1^', # not canonicalized
           }]
         }]
-      )
+      })
 
       expect(JSON.parse(tpl_output)).to eq({
         "credhub.cf.internal" => [


### PR DESCRIPTION
This updates the spec syntax to work with ruby3.1. There were errors without the wrapping `{}` the the params for `template.render()`

add lightweight workflow that tests rendering with ruby 2.7 and 3.1