### PR TITLE
Resolving external services

### DIFF
--- a/jobs/bosh-dns-aliases/spec
+++ b/jobs/bosh-dns-aliases/spec
@@ -22,3 +22,9 @@ properties:
         deployment: cf_123
         network: default
         domain: bosh
+    - domain: svc1.xxx.com
+      targets: ["10.193.78.10", "10.193.78.11"]
+    - domain: svc2.xxx.com
+      targets:
+      - "10.193.78.20"
+      - "10.193.78.21"

--- a/jobs/bosh-dns-aliases/templates/aliases.json.erb
+++ b/jobs/bosh-dns-aliases/templates/aliases.json.erb
@@ -10,13 +10,17 @@ aliases = p("aliases").map do |a|
   [
     a.fetch("domain"),
     a.fetch("targets").map do |t|
-      [
-        t.fetch("query"),
-        canonicalize(t.fetch("instance_group")),
-        canonicalize(t.fetch("network")),
-        canonicalize(t.fetch("deployment")),
-        t.fetch("domain", spec.dns_domain_name),
-      ].join(".")
+      if t.is_a? String
+        t
+      else
+        [
+          t.fetch("query"),
+          canonicalize(t.fetch("instance_group")),
+          canonicalize(t.fetch("network")),
+          canonicalize(t.fetch("deployment")),
+          t.fetch("domain", spec.dns_domain_name),
+        ].join(".")
+      end
     end,
   ]
 end

--- a/jobs/bosh-dns-aliases/templates/aliases.json.erb
+++ b/jobs/bosh-dns-aliases/templates/aliases.json.erb
@@ -10,7 +10,7 @@ aliases = p("aliases").map do |a|
   [
     a.fetch("domain"),
     a.fetch("targets").map do |t|
-      if t.is_a? String
+      if t.kind_of?(String)
         t
       else
         [


### PR DESCRIPTION
I want to add custom DNS records via BOSH DNS aliases to resolve the external services, as described here: https://pvtl.force.com/s/article/5000e00001iMrXM1583461332724

In my basic configuration I would like jobs to resolve services using Bosh DNS query.
But in case of testing (or for example trouble, migration of the services) I would like to switch the jobs to external services (without changes in the jobs config).
I believe that using Bosh DNS Aliases in this case is a good choice because I can still use Bosh DNS query:
```yaml
- domain: test.svc
  targets:
  - query: 'q-s0'
    instance_group: api
    deployment: cf
    network: default
    domain: bosh
```
and easily change it to the external service:
```yaml
- domain: test.svc
  targets:
   - '8.8.8.8'
   - '8.8.4.4'
```

Pre-release: https://github.com/kinjelom/bosh-dns-aliases-release/releases/tag/v0.0.5